### PR TITLE
EI-984 Update velero resource limits as default limits failing full b…

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -98,6 +98,14 @@ resource "helm_release" "velero_install" {
     name  = "configuration.backupStorageLocation.config.resourceGroup"
     value = var.aks_resource_group_name
   }
+  set {
+    name  = "resources.limits.cpu"
+    value = "2000m"
+  }
+  set {
+    name  = "resources.limits.memory"
+    value = "1024Mi"
+  }
 
   wait    = true
   timeout = 300


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EI-984


### Change description ###
Updating velero deployment resources to 2 CPU and 1Gb Memory as the defaults are not enough we take full cluster backups.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
