### PR TITLE
Dev ei 1259

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -10,10 +10,11 @@ resource "time_sleep" "wait_for_loadbalancer" {
 data "kubernetes_service" "mgmt_gateway_svc" {
   metadata {
     name      = "istio-ingressgateway-mgmt"
-    namespace = "istio-ingress"
+    namespace = "istio-ingress-mgmt"
   }
   depends_on = [
-    time_sleep.wait_for_loadbalancer
+    time_sleep.wait_for_loadbalancer,
+    kubernetes_namespace.istio_ingress_mgmt_namespace
   ]
 }
 
@@ -23,17 +24,19 @@ data "kubernetes_service" "app_gateway_svc" {
     namespace = "istio-ingress"
   }
   depends_on = [
-    time_sleep.wait_for_loadbalancer
+    time_sleep.wait_for_loadbalancer,
+    kubernetes_namespace.istio_ingress_namespace
   ]
 }
 
 data "kubernetes_service" "web_gateway_svc" {
   metadata {
     name      = "istio-ingressgateway-web"
-    namespace = "istio-ingress"
+    namespace = "istio-ingress-web"
   }
   depends_on = [
-    time_sleep.wait_for_loadbalancer
+    time_sleep.wait_for_loadbalancer,
+    kubernetes_namespace.istio_ingress_web_namespace
   ]
 }
 

--- a/istio.tf
+++ b/istio.tf
@@ -437,7 +437,6 @@ data "kubectl_file_documents" "istio_ingress_gateway_manifests" {
 resource "kubectl_manifest" "install_istio_ingress_gateway_manifests" {
   count              = length(split("\n---\n", file("${path.module}/manifests/istio/istio_ingress_gateway.yaml")))
   yaml_body          = element(data.kubectl_file_documents.istio_ingress_gateway_manifests.documents, count.index)
-  override_namespace = "istio-ingress"
   depends_on = [
     kubectl_manifest.cert-manager-install,
     kubectl_manifest.cert_issuer_install,

--- a/istio.tf
+++ b/istio.tf
@@ -21,6 +21,30 @@ resource "kubernetes_namespace" "istio_ingress_namespace" {
   depends_on = [time_sleep.wait_for_aks_api_dns_propagation]
 }
 
+resource "kubernetes_namespace" "istio_ingress_mgmt_namespace" {
+  metadata {
+    name = "istio-ingress-mgmt"
+    labels = {
+      "app.kubernetes.io/managed-by" = "Terraform"
+      "filebeat_enable"              = "enabled"
+      "istio-injection"              = "enabled"
+    }
+  }
+  depends_on = [time_sleep.wait_for_aks_api_dns_propagation]
+}
+
+resource "kubernetes_namespace" "istio_ingress_web_namespace" {
+  metadata {
+    name = "istio-ingress-web"
+    labels = {
+      "app.kubernetes.io/managed-by" = "Terraform"
+      "filebeat_enable"              = "enabled"
+      "istio-injection"              = "enabled"
+    }
+  }
+  depends_on = [time_sleep.wait_for_aks_api_dns_propagation]
+}
+
 data "kubectl_path_documents" "istio_crd_manifests" {
   pattern = "${path.module}/manifests/istio/crds/${lookup(var.charts.istio-base, "version", "")}/crd-all.gen.yaml"
 }
@@ -146,7 +170,7 @@ resource "helm_release" "istio_ingress_mgmt_install" {
   chart      = lookup(var.charts.istio-ingress, "name", "istio-ingress")
   version    = lookup(var.charts.istio-ingress, "version", "")
   repository = "./install"
-  namespace  = "istio-ingress"
+  namespace  = "istio-ingress-mgmt"
 
   set {
     name  = "gateways.istio-ingressgateway.name"
@@ -233,7 +257,7 @@ resource "helm_release" "istio_ingress_mgmt_install" {
 
   depends_on = [
     null_resource.download_charts,
-    kubernetes_namespace.istio_ingress_namespace,
+    kubernetes_namespace.istio_ingress_mgmt_namespace,
     helm_release.istio_base_install,
     helm_release.istiod_install
   ]
@@ -325,7 +349,7 @@ resource "helm_release" "istio_ingress_web_install" {
   chart      = lookup(var.charts.istio-ingress, "name", "istio-ingress")
   version    = lookup(var.charts.istio-ingress, "version", "")
   repository = "./install"
-  namespace  = "istio-ingress"
+  namespace  = "istio-ingress-web"
 
   set {
     name  = "gateways.istio-ingressgateway.name"
@@ -392,7 +416,7 @@ resource "helm_release" "istio_ingress_web_install" {
 
   depends_on = [
     null_resource.download_charts,
-    kubernetes_namespace.istio_ingress_namespace,
+    kubernetes_namespace.istio_ingress_web_namespace,
     helm_release.istio_base_install,
     helm_release.istiod_install
   ]

--- a/istio.tf
+++ b/istio.tf
@@ -435,8 +435,8 @@ data "kubectl_file_documents" "istio_ingress_gateway_manifests" {
 }
 
 resource "kubectl_manifest" "install_istio_ingress_gateway_manifests" {
-  count              = length(split("\n---\n", file("${path.module}/manifests/istio/istio_ingress_gateway.yaml")))
-  yaml_body          = element(data.kubectl_file_documents.istio_ingress_gateway_manifests.documents, count.index)
+  count     = length(split("\n---\n", file("${path.module}/manifests/istio/istio_ingress_gateway.yaml")))
+  yaml_body = element(data.kubectl_file_documents.istio_ingress_gateway_manifests.documents, count.index)
   depends_on = [
     kubectl_manifest.cert-manager-install,
     kubectl_manifest.cert_issuer_install,

--- a/kiali.tf
+++ b/kiali.tf
@@ -77,7 +77,7 @@ resource "helm_release" "kiali_operator_install" {
 resource "kubectl_manifest" "install_kiali_virtualservice_manifests" {
   yaml_body = templatefile("${path.module}/manifests/kiali/virtualservice.yaml", {
     namespace         = "istio-system"
-    gateway           = "istio-ingress/istio-ingressgateway-mgmt"
+    gateway           = "istio-ingress-mgmt/istio-ingressgateway-mgmt"
     kiali_hostnames   = var.kiali_hostnames
     kiali_destination = "kiali"
   })

--- a/manifests/cert-manager/cert-issuer.yaml
+++ b/manifests/cert-manager/cert-issuer.yaml
@@ -26,7 +26,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: istio-ingressgateway-mgmt-cert
-  namespace: "istio-ingress"
+  namespace: "istio-ingress-mgmt"
 spec:
   commonName: "${element(istio_ingress_mgmt_domains, 0)}"
   duration: 2160h # 90d
@@ -62,7 +62,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: istio-ingressgateway-web-cert
-  namespace: "istio-ingress"
+  namespace: "istio-ingress-web"
 spec:
   commonName: "${element(istio_ingress_web_domains, 0)}"
   duration: 2160h # 90d

--- a/manifests/istio/istio_ingress_gateway.yaml
+++ b/manifests/istio/istio_ingress_gateway.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: istio-ingressgateway-mgmt
-  namespace: istio-ingress
+  namespace: istio-ingress-mgmt
 spec:
   selector:
     istio: ingressgateway-mgmt
@@ -69,7 +69,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: istio-ingressgateway-web
-  namespace: istio-ingress
+  namespace: istio-ingress-web
 spec:
   selector:
     istio: ingressgateway-web

--- a/pgadmin.tf
+++ b/pgadmin.tf
@@ -65,6 +65,10 @@ resource "helm_release" "pgadmin" {
     value = var.pgadmin_oauth2_clientsecret
   }
   set {
+    name  = "gateway.name"
+    value = "istio-ingress-mgmt/istio-ingressgateway-mgmt"
+  }
+  set {
     name  = "gateway.host"
     value = var.pgadmin_hostnames
   }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -77,7 +77,7 @@ resource "helm_release" "prometheus_adapter_install" {
 resource "kubectl_manifest" "install_grafana_virtualservice_manifests" {
   yaml_body = templatefile("${path.module}/manifests/prometheus/virtualservice_grafana.yaml", {
     namespace           = "prometheus"
-    gateway             = "istio-ingress/istio-ingressgateway-mgmt"
+    gateway             = "istio-ingress-mgmt/istio-ingressgateway-mgmt"
     grafana_hostnames   = var.grafana_hostnames
     grafana_destination = "${helm_release.prometheus.name}-grafana"
   })

--- a/sonarqube.tf
+++ b/sonarqube.tf
@@ -48,6 +48,10 @@ resource "helm_release" "sonarqube_install" {
     name  = "gateway.host"
     value = var.sonarqube_config.sonarqubeUrl
   }
+  set {
+    name  = "gateway.name"
+    value = "istio-ingress-mgmt/istio-ingressgateway-mgmt"
+  }
   values = [templatefile("${path.module}/manifests/common/sonarProps.yaml", {
     tenant_id    = data.azurerm_client_config.current.tenant_id
     sonarqubeUrl = var.sonarqube_config.sonarqubeUrl


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EI-1259

### Change description ###

Split gateways into own namespaces to have a double level of separation between Istio Gateways and traffic which comes through them into the cluster, so no single bug/mistake can expose services running in the cluster.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
