### PR TITLE
EI-1166 : Cert manager cert should be read from Vault

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -38,7 +38,7 @@ data "kubectl_file_documents" "cert_issuer_manifests" {
     vault_token                         = base64encode(var.vault_token)
     vault_path                          = var.vault_path
     vault_url                           = var.vault_url
-    ca_bundle                           = filebase64(var.ca_bundle_path)
+    ca_bundle                           = data.vault_generic_secret.ca_cert.data.issuing_ca
     istio_gateway_mgmt_cert_secret_name = var.istio_gateway_mgmt_cert_secret_name
     istio_gateway_apps_cert_secret_name = var.istio_gateway_apps_cert_secret_name
     istio_gateway_web_cert_secret_name  = var.istio_gateway_web_cert_secret_name

--- a/data.tf
+++ b/data.tf
@@ -96,3 +96,7 @@ data "vault_generic_secret" "sonaqube_cred" {
   count = var.sonarqube_config.enable ? 1 : 0
   path  = var.sonarqube_config.sonarVaultPath
 }
+
+data "vault_generic_secret" "ca_cert" {
+  path  = var.ca_bundle_path
+}

--- a/data.tf
+++ b/data.tf
@@ -98,5 +98,5 @@ data "vault_generic_secret" "sonaqube_cred" {
 }
 
 data "vault_generic_secret" "ca_cert" {
-  path  = var.ca_bundle_path
+  path = var.ca_bundle_path
 }

--- a/velero.tf
+++ b/velero.tf
@@ -88,7 +88,7 @@ resource "helm_release" "velero_install" {
   }
   set {
     name  = "configuration.backupStorageLocation.caCert"
-    value = filebase64(var.ca_bundle_path)
+    value = data.vault_generic_secret.ca_cert.data.issuing_ca
   }
   set {
     name  = "configuration.backupStorageLocation.config.storageAccount"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EI-1166

### Change description ###

I want certificate needed for cert manager to be read from Vault . Current as part of AKS config we provide the path as vars and we expect that path to have respective cert which makes it difficult to run locally without creating path and cert in the expected path .

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
