### PR TITLE
dev/ei-1715

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -106,6 +106,14 @@ resource "helm_release" "velero_install" {
     name  = "resources.limits.memory"
     value = "1024Mi"
   }
+  set {
+    name  = "kubectl.image.repository"
+    value = "${var.acr_name}.azurecr.io/registry.hub.docker.com/bitnami/kubectl"
+  }
+  set {
+    name  = "kubectl.image.tag"
+    value = "latest"
+  }
 
   wait    = true
   timeout = 300


### PR DESCRIPTION
### Jira link (if applicable)

EI-1715

### Change description ###

change reference to image for velero regarding dependent kubectl image as the external repo access is blocked.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
