### PR TITLE
chore(cert-manager): bumping webhook replicas from 2 to 3

### DIFF
--- a/manifests/cert-manager/cert-manager.yaml
+++ b/manifests/cert-manager/cert-manager.yaml
@@ -5473,7 +5473,7 @@ metadata:
     app.kubernetes.io/component: "webhook"
     app.kubernetes.io/version: "v1.13.3"
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/EI-2016

### Change description ###

Bumping cert-manager webhook replicas from 2 to 3

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
