### PR TITLE
Changing azure alert flag to false for DTSPO-19775

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -395,7 +395,7 @@ variable "alerts" {
     })
   })
   default = {
-    enable_alerts = true
+    enable_alerts = false
     infra = {
       enabled                  = true
       cpu_usage_threshold      = 80


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-19775

### Change description
Setting the enable_alerts flag to false as per DTSPO-19775. This should disable all azure alerts that are currently enabled on AKS clusters. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
