### PR TITLE
DTSPO-24552 Enable Kubernetes Native Sidecars support in Istio

### DIFF
--- a/ado-agents.tf
+++ b/ado-agents.tf
@@ -4,7 +4,6 @@ resource "kubernetes_namespace" "ado-agents_namespace" {
     name = var.ado-agents_config.namespace
     labels = {
       "app.kubernetes.io/managed-by" = "Terraform"
-      "istio-injection"              = "disabled"
     }
   }
   depends_on = [time_sleep.wait_for_aks_api_dns_propagation]

--- a/istio.tf
+++ b/istio.tf
@@ -172,6 +172,7 @@ resource "helm_release" "istiod_install" {
     name  = "pilot.resources.requests.memory"
     value = var.istiod_memory_request
   }
+
   set {
     name  = "pilot.resources.requests.cpu"
     value = var.istiod_cpu_request
@@ -180,6 +181,11 @@ resource "helm_release" "istiod_install" {
   set {
     name  = "pilot.cpu.targetAverageUtilization"
     value = var.istiod_hpa_cputarget
+  }
+
+  set {
+    name  = "pilot.env.ENABLE_NATIVE_SIDECARS"
+    value = "true"
   }
 
   values = ["${file("${path.module}/manifests/istio/istiod_overrides.yaml")}"]


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24552

### Change description

This will enable Kubernetes Native Sidecars support for Istio.
We need this feature to automatically kill the proxy for k8s Jobs instead of the existing hacks.
More on this: https://istio.io/latest/blog/2023/native-sidecars

### Testing done

Tested on Dev cluster

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
