### PR TITLE
fix: restore SonarQube custom values lost in chart upgrade to 2026.1.0

### DIFF
--- a/sonarqube.tf
+++ b/sonarqube.tf
@@ -78,6 +78,38 @@ resource "helm_release" "sonarqube_install" {
     name  = "initSysctl.enabled"
     value = true
   }
+  set {
+    name  = "securityContext.fsGroup"
+    value = 1000
+  }
+  set {
+    name  = "gateway.serviceDestinationPort"
+    value = 9000
+  }
+  set {
+    name  = "gateway.timeout"
+    value = "120s"
+  }
+  set {
+    name  = "persistence.enabled"
+    value = true
+  }
+  set {
+    name  = "nodeSelector.agentpool"
+    value = "sysagentpool"
+  }
+  set {
+    name  = "tolerations[0].key"
+    value = "CriticalAddonsOnly"
+  }
+  set {
+    name  = "tolerations[0].operator"
+    value = "Exists"
+  }
+  set {
+    name  = "tolerations[0].effect"
+    value = "NoSchedule"
+  }
 
   values = [templatefile("${path.module}/manifests/common/sonarProps.yaml", {
     tenant_id    = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30616

### Change description

fix: restore SonarQube custom values lost in chart upgrade to 2026.1.0

- Add gateway.serviceDestinationPort=9000 to fix 503 errors
- Restore gateway.timeout=120s for long-running analysis
- Re-enable persistence for plugins and ES data
- Restore nodeSelector and tolerations for sysagentpool scheduling

Chart upgrade from 2025.6.0 to 2026.1.0 removed PostgreSQL dependency
and reset custom values to upstream defaults.

### Testing done

Tested on dev non active cluster

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
