### PR TITLE
Fix k8s api timeout issues by scaling konnectivity agents

### DIFF
--- a/konnectivity-agent-autoscaler.tf
+++ b/konnectivity-agent-autoscaler.tf
@@ -1,0 +1,16 @@
+resource "kubectl_manifest" "konnectivity_agent_autoscaler_configmap" {
+  count = var.konnectivity_agent_autoscaler.enabled ? 1 : 0
+
+  yaml_body = templatefile("${path.module}/manifests/konnectivity-agent-autoscaler/configmap.yaml", {
+    ladder = jsonencode({
+      coresToReplicas = var.konnectivity_agent_autoscaler.cores_to_replicas
+      nodesToReplicas = var.konnectivity_agent_autoscaler.nodes_to_replicas
+    })
+  })
+
+  lifecycle {
+    ignore_changes = [field_manager]
+  }
+
+  depends_on = [time_sleep.wait_for_aks_api_dns_propagation]
+}

--- a/manifests/konnectivity-agent-autoscaler/configmap.yaml
+++ b/manifests/konnectivity-agent-autoscaler/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: konnectivity-agent-autoscaler
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+    app: konnectivity-agent-autoscaler
+    kubernetes.io/cluster-service: "true"
+data:
+  ladder: |-
+    ${ladder}

--- a/variables.tf
+++ b/variables.tf
@@ -402,6 +402,20 @@ variable "container_azm_ms_agentconfig" {
   }
 }
 
+variable "konnectivity_agent_autoscaler" {
+  description = "Overrides the node-count-to-replica ladder used by the AKS-managed kube-system/konnectivity-agent-autoscaler ConfigMap. Only applied when enabled = true; leave disabled to keep the AKS default."
+  type = object({
+    enabled           = bool
+    cores_to_replicas = optional(list(list(number)), [])
+    nodes_to_replicas = optional(list(list(number)), [])
+  })
+  default = {
+    enabled           = false
+    cores_to_replicas = []
+    nodes_to_replicas = []
+  }
+}
+
 variable "alerts" {
   type = object({
     enable_alerts = bool


### PR DESCRIPTION
This is to fix AKS api timeouts due to load on konnectivity agents